### PR TITLE
v4 to v1

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -34,7 +34,7 @@ suite.add('uuid.v4', function () {
 })
 
 suite.add('uuid.v1', function () {
-  uuid.v4()
+  uuid.v1()
 })
 
 suite.add('hyperid', function () {


### PR DESCRIPTION
I read the benchmark test and I saw that for the uuid.v1 you used uuid.v4 instead of uuid.v1, a typo, I guess