### PR TITLE
Added functionality to enable fixed length generated IDs. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ console.log(hyperid.decode(instance()))
 
 Returns a function to generate unique ids.
 
-### instance()
+### instance(fixedLength)
 
 Returns an unique id.
+If `fixedLength` is passed in as `true` then the generated id will always be 33
+characters in length, by default `fixedLength` is `false`.
 
 ### instance.uuid
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,17 @@ Uber-fast unique id generation, for Node.js and the browser.
 Here are the benchmarks:
 
 ```
-hashids process.hrtime x 27,255 ops/sec ±0.71% (91 runs sampled)
-hashids counter x 55,038 ops/sec ±1.32% (88 runs sampled)
-shortid x 33,322 ops/sec ±2.77% (75 runs sampled)
-nid x 1,027,557 ops/sec ±1.08% (86 runs sampled)
-uuid.v4 x 342,969 ops/sec ±1.37% (89 runs sampled)
-uuid.v1 x 316,735 ops/sec ±3.56% (83 runs sampled)
-hyperid x 9,131,590 ops/sec ±4.83% (73 runs sampled)
+hashids process.hrtime x 32,750 ops/sec ±0.65% (89 runs sampled)
+hashids counter x 67,476 ops/sec ±0.66% (90 runs sampled)
+shortid x 55,419 ops/sec ±2.09% (87 runs sampled)
+nid x 578,914 ops/sec ±0.63% (96 runs sampled)
+uuid.v4 x 510,042 ops/sec ±1.85% (91 runs sampled)
+uuid.v1 x 2,293,920 ops/sec ±0.53% (95 runs sampled)
+hyperid - variable length x 11,888,473 ops/sec ±1.08% (87 runs sampled)
+hyperid - fixed length x 11,049,988 ops/sec ±3.78% (83 runs sampled)
 ```
+
+_Note:_ Benchmark run with Intel i7-4810MQ @ 2.80GHz using Node v7.2.0
 
 ## Install
 
@@ -40,15 +43,15 @@ console.log(hyperid.decode(instance()))
 
 ## API
 
-### hyperid()
+### hyperid(fixedLength)
 
 Returns a function to generate unique ids.
+If `fixedLength` is passed in as `true` the function will always generate an id
+that is 33 characters in length, by default `fixedLength` is `false`.
 
-### instance(fixedLength)
+### instance()
 
 Returns an unique id.
-If `fixedLength` is passed in as `true` then the generated id will always be 33
-characters in length, by default `fixedLength` is `false`.
 
 ### instance.uuid
 

--- a/benchmark.js
+++ b/benchmark.js
@@ -37,8 +37,12 @@ suite.add('uuid.v1', function () {
   uuid.v1()
 })
 
-suite.add('hyperid', function () {
+suite.add('hyperid - variable length', function () {
   hyperid()
+})
+
+suite.add('hyperid - fixed length', function () {
+  hyperid(true)
 })
 
 suite.on('cycle', cycle)

--- a/hyperid.js
+++ b/hyperid.js
@@ -3,13 +3,13 @@
 const uuid = require('uuid')
 const maxInt = Math.pow(2, 31) - 1
 
-function hyperid () {
+function hyperid (fixedLength) {
   var count = 0
 
   generate.uuid = uuid.v4()
   var id = baseId(generate.uuid)
 
-  function generate (fixedLength) {
+  function generate () {
     var result = fixedLength
       ? id + pad(count++)
       : id + count++

--- a/hyperid.js
+++ b/hyperid.js
@@ -9,8 +9,10 @@ function hyperid () {
   generate.uuid = uuid.v4()
   var id = baseId(generate.uuid)
 
-  function generate () {
-    var result = id + count++
+  function generate (fixedLength = false) {
+    var result = fixedLength
+      ? id + pad(count++)
+      : id + count++
 
     if (count === maxInt) {
       generate.uuid = uuid.v4()
@@ -24,6 +26,18 @@ function hyperid () {
   generate.decode = decode
 
   return generate
+}
+
+function pad (count) {
+  if (count < 10) return `000000000${count}`
+  if (count < 100) return `00000000${count}`
+  if (count < 1000) return `0000000${count}`
+  if (count < 10000) return `000000${count}`
+  if (count < 100000) return `00000${count}`
+  if (count < 1000000) return `0000${count}`
+  if (count < 10000000) return `000${count}`
+  if (count < 100000000) return `00${count}`
+  if (count < 1000000000) return `0${count}`
 }
 
 function baseId (id) {

--- a/hyperid.js
+++ b/hyperid.js
@@ -9,7 +9,7 @@ function hyperid () {
   generate.uuid = uuid.v4()
   var id = baseId(generate.uuid)
 
-  function generate (fixedLength = false) {
+  function generate (fixedLength) {
     var result = fixedLength
       ? id + pad(count++)
       : id + count++

--- a/test.js
+++ b/test.js
@@ -23,6 +23,23 @@ test('generating unique ids', function (t) {
   t.pass(ids.length + ' id generated')
 })
 
+test('generating unique ids are correct length when fixedLength set to true', function (t) {
+  t.plan(1)
+
+  const instance = hyperid()
+
+  for (var i = 0; i < 1000000; i++) {
+    const id = instance(true)
+
+    if (id.length !== 33) {
+      t.fail('incorrect length')
+      return
+    }
+  }
+
+  t.pass('1000000 id of 33 characters generated')
+})
+
 test('decode uuids', function (t) {
   t.plan(4)
 

--- a/test.js
+++ b/test.js
@@ -26,10 +26,10 @@ test('generating unique ids', function (t) {
 test('generating unique ids are correct length when fixedLength set to true', function (t) {
   t.plan(1)
 
-  const instance = hyperid()
+  const instance = hyperid(true)
 
   for (var i = 0; i < 1000000; i++) {
-    const id = instance(true)
+    const id = instance()
 
     if (id.length !== 33) {
       t.fail('incorrect length')


### PR DESCRIPTION
Problem
------------
New functionality in AutoCannon makes use of HyperID but requires the ability to generate fixed length IDs in order to optimise performance.

Solution
------------
Iteration part of generated ID padded to 10 characters when fixedLength parameter is passed in as true. Results in consistent total length of 33 characters for generated IDs.

Notes
---------
Implementation uses custom pad function, originally tried using [pad-left](https://github.com/jonschlinkert/pad-left) but use of custom pad function saw a large performance increase when running the benchmark on my machine. 

Added test which ensures this performs consistently for 1,000,000 IDs, tested without committing for 1,000,000,000 IDs and performance is correct. Did not commit this as it would cause the test suite to take ~2 minutes to run. 

Added to benchmark, but did not update this section in the README as I saw different results for existing performance benchmarks compared to current results (think I have a faster machine than the one used to generate them). Suggest running the benchmark locally when merging in order to update with new figure.