### PR TITLE
Use `export =` to match JS export layout.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,4 +22,4 @@ declare namespace hyperid {
   }
 }
 
-export default hyperid
+export = hyperid

--- a/test/example.ts
+++ b/test/example.ts
@@ -1,4 +1,4 @@
-import hyperid from '..'
+import * as hyperid from '..'
 
 const urlSafeInstance = hyperid({ fixedLength: false, urlSafe: true })
 const fixedLengthInstance = hyperid(true)


### PR DESCRIPTION
Typescript's "export default" is equivalent to `module.exports.default = hyperid` but the JS source is using `module.exports = hyperid`, so the Typescript definitions weren't working for me. I confirmed that executing `example.ts` now works as well.

@HelloEdit can you confirm? Were you seeing a different behavior from Typescript?