### PR TITLE
Add optional options param to decode signature.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ declare namespace hyperid {
     uuid: string
   }
 
-  type decode = (id: string) => hyperid.IdObject
+  type decode = (id: string, opts?: hyperid.Options) => hyperid.IdObject
 
   interface IdObject {
     uuid: string


### PR DESCRIPTION
Typings for `decode` were missing the optional `opts` parameter, this has been corrected.