### PR TITLE
tidy up shipped package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "hyperid",
   "files": [
     "hyperid.js",
-    "index.d.ts"
+    "index.d.ts",
+    "test"
   ],
   "scripts": {
     "typescript": "tsc --project ./test/tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "2.0.3",
   "description": "Uber-fast unique id generation, for Node.js and the browser",
   "main": "hyperid",
+  "files": [
+    "hyperid.js",
+    "index.d.ts"
+  ],
   "scripts": {
     "typescript": "tsc --project ./test/tsconfig.json",
     "test": "standard && tape test/test.js test/uniqueness.js | tap-dot && npm run typescript"


### PR DESCRIPTION
shipped tidy up:
```
{17:45}~/opensource/hyperid:master ✓ ➭ git checkout patch-2
Switched to branch 'patch-2'
Your branch is up to date with 'origin/patch-2'.
{17:45}~/opensource/hyperid:patch-2 ✓ ➭ npm pack
npm notice 
npm notice 📦  hyperid@2.0.3
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE     
npm notice 2.1kB hyperid.js  
npm notice 1.1kB package.json
npm notice 2.1kB README.md   
npm notice 456B  index.d.ts  
npm notice === Tarball Details === 
...
npm notice package size:  3.0 kB                                  
npm notice unpacked size: 6.8 kB   
```
vs, shipped unfiltered 
```
{17:42}~/opensource/hyperid:patch-2 ✓ ➭ git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
{17:43}~/opensource/hyperid:master ✓ ➭ npm pack
npm notice 
npm notice 📦  hyperid@2.0.3
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE           
npm notice 913B  benchmark.js      
npm notice 206B  example.js        
npm notice 2.1kB hyperid.js        
npm notice 1.9kB test/test.js      
npm notice 1.4kB test/uniqueness.js
npm notice 1.0kB package.json      
npm notice 154B  test/tsconfig.json
npm notice 2.1kB README.md         
npm notice 330B  test/example.ts   
npm notice 456B  index.d.ts        
npm notice 79B   .travis.yml       
npm notice === Tarball Details === 
...
npm notice package size:  4.2 kB                                  
npm notice unpacked size: 11.8 kB 
```