### PR TITLE
feat: avoid regex for end of id

### DIFF
--- a/hyperid.js
+++ b/hyperid.js
@@ -62,10 +62,17 @@ function pad (count) {
 
 function baseId (id, urlSafe) {
   var base64Id = Buffer.from(parser.parse(id)).toString('base64')
+  var l = base64Id.length
   if (urlSafe) {
-    return base64Id.replace(/\+/g, '_').replace(/\//g, '-').replace(/==$/, '-')
+    if (base64Id[l - 2] === '=' && base64Id[l - 1] === '=') {
+      base64Id = base64Id.substr(0, l - 2) + '-'
+    }
+    return base64Id.replace(/\+/g, '_').replace(/\//g, '-')
   }
-  return base64Id.replace(/==$/, '/')
+  if (base64Id[l - 2] === '=' && base64Id[l - 1] === '=') {
+    return base64Id.substr(0, l - 2) + '/'
+  }
+  return base64Id
 }
 
 function decode (id, opts) {


### PR DESCRIPTION
Using regex for replacing the end of the `base64Id` is a bit overkill as we know the position of it. This gain a bit of performance. (tests on Node 14.15.1)

Reference:
```
$ node benchmark.js
hyperid - variable length x 13,308,866 ops/sec ±1.14% (92 runs sampled)
hyperid - fixed length x 13,234,679 ops/sec ±0.84% (92 runs sampled)
hyperid - fixed length, url safe x 13,416,852 ops/sec ±1.35% (93 runs sampled)
```

With changes:
```
$ node benchmark.js 
hyperid - variable length x 13,576,324 ops/sec ±0.85% (91 runs sampled)
hyperid - fixed length x 13,389,711 ops/sec ±0.75% (93 runs sampled)
hyperid - fixed length, url safe x 13,733,617 ops/sec ±0.95% (93 runs sampled)
```

One other thing would be to use a cursor instead of regex for this line:
```js
return base64Id.replace(/\+/g, '_').replace(/\//g, '-')
```
But not sure if the benefits worth the hassle.