### PR TITLE
bump packages version

### DIFF
--- a/hyperid.js
+++ b/hyperid.js
@@ -6,8 +6,8 @@ const maxInt = Math.pow(2, 31) - 1
 const Buffer = require('buffer').Buffer
 
 function hyperid (opts) {
-  var fixedLength = false
-  var urlSafe = false
+  let fixedLength = false
+  let urlSafe = false
   if (typeof opts === 'boolean') {
     fixedLength = opts
   } else {
@@ -19,8 +19,8 @@ function hyperid (opts) {
   generate.uuid = uuidv4()
   generate.decode = decode
 
-  var id = baseId(generate.uuid, urlSafe)
-  var count = Math.floor(opts.startFrom || 0)
+  let id = baseId(generate.uuid, urlSafe)
+  let count = Math.floor(opts.startFrom || 0)
 
   if (isNaN(count) || !(maxInt > count && count >= 0)) {
     throw new Error([
@@ -33,7 +33,7 @@ function hyperid (opts) {
   return generate
 
   function generate () {
-    var result = fixedLength
+    const result = fixedLength
       ? id + pad(count++)
       : id + count++
 
@@ -61,8 +61,8 @@ function pad (count) {
 }
 
 function baseId (id, urlSafe) {
-  var base64Id = Buffer.from(parser.parse(id)).toString('base64')
-  var l = base64Id.length
+  let base64Id = Buffer.from(parser.parse(id)).toString('base64')
+  const l = base64Id.length
   if (urlSafe) {
     if (base64Id[l - 2] === '=' && base64Id[l - 1] === '=') {
       base64Id = base64Id.substr(0, l - 2) + '-'
@@ -77,7 +77,7 @@ function baseId (id, urlSafe) {
 
 function decode (id, opts) {
   opts = opts || {}
-  var urlSafe = !!opts.urlSafe
+  const urlSafe = !!opts.urlSafe
 
   if (urlSafe) {
     id = id.replace(/-/g, '/').replace(/_/g, '+')

--- a/hyperid.js
+++ b/hyperid.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const uuid = require('uuid/v4')
+const { v4: uuidv4 } = require('uuid')
 const parser = require('uuid-parse')
 const maxInt = Math.pow(2, 31) - 1
 const Buffer = require('buffer').Buffer
@@ -16,7 +16,7 @@ function hyperid (opts) {
     fixedLength = !!opts.fixedLength
   }
 
-  generate.uuid = uuid()
+  generate.uuid = uuidv4()
   generate.decode = decode
 
   var id = baseId(generate.uuid, urlSafe)
@@ -38,7 +38,7 @@ function hyperid (opts) {
       : id + count++
 
     if (count === maxInt) {
-      generate.uuid = uuid()
+      generate.uuid = uuidv4()
       id = baseId(generate.uuid, urlSafe) // rebase
       count = 0
     }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "benchmark": "^2.1.4",
     "bloomfilter": "0.0.18",
-    "hashids": "^1.2.2",
+    "hashids": "^2.2.8",
     "nanoid": "^3.1.20",
     "nid": "^1.1.0",
     "pre-commit": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "uuid": "^3.4.0",
+    "uuid": "^8.3.2",
     "uuid-parse": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "standard": "^14.0.0",
     "tap-dot": "^2.0.0",
     "tape": "^5.0.0",
-    "typescript": "^3.8.3"
+    "typescript": "^4.3.4"
   },
   "dependencies": {
     "uuid": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "nid": "^1.1.0",
     "pre-commit": "^1.2.2",
     "shortid": "^2.2.15",
-    "standard": "^14.0.0",
+    "standard": "^16.0.3",
     "tap-dot": "^2.0.0",
     "tape": "^5.0.0",
     "typescript": "^4.3.4"

--- a/test/test.js
+++ b/test/test.js
@@ -9,7 +9,7 @@ test('generating unique ids', function (t) {
   const instance = hyperid()
   const ids = []
 
-  for (var i = 0; i < 2048; i++) {
+  for (let i = 0; i < 2048; i++) {
     const id = instance()
 
     if (ids.indexOf(id) >= 0) {
@@ -28,7 +28,7 @@ test('generating unique ids are correct length when fixedLength set to true', fu
 
   const instance = hyperid(true)
 
-  for (var i = 0; i < 1000000; i++) {
+  for (let i = 0; i < 1000000; i++) {
     const id = instance()
 
     if (id.length !== 33) {
@@ -45,7 +45,7 @@ test('generating unique ids are correct length when fixedLength set to true (as 
 
   const instance = hyperid({ fixedLength: true })
 
-  for (var i = 0; i < 1000000; i++) {
+  for (let i = 0; i < 1000000; i++) {
     const id = instance()
 
     if (id.length !== 33) {

--- a/test/uniqueness.js
+++ b/test/uniqueness.js
@@ -14,12 +14,12 @@ test('uniqueness', function (t) {
     16 // number of hash functions.
   )
 
-  var conflicts = 0
-  var ids = 0
+  let conflicts = 0
+  let ids = 0
 
   const max = maxInt * 2
 
-  for (var i = 0; i < max; i += Math.ceil(Math.random() * 4096)) {
+  for (let i = 0; i < max; i += Math.ceil(Math.random() * 4096)) {
     const id = instance()
 
     if (bloom.test(id)) {
@@ -45,12 +45,12 @@ test('url safe uniqueness', function (t) {
     16 // number of hash functions.
   )
 
-  var conflicts = 0
-  var ids = 0
+  let conflicts = 0
+  let ids = 0
 
   const max = maxInt * 2
 
-  for (var i = 0; i < max; i += Math.ceil(Math.random() * 4096)) {
+  for (let i = 0; i < max; i += Math.ceil(Math.random() * 4096)) {
     const id = instance()
 
     if (bloom.test(id)) {


### PR DESCRIPTION
Resolves #23 
This Pull Request increases the uuid version and some outdated dev dependencies:
- Bump uuid & fix import (https://github.com/uuidjs/uuid/blob/master/CHANGELOG.md#800-2020-04-29)
- Bump standard & apply automatic fixes
  - Not 100% sure about this change. Is the package compiled so that it also works for older browser with the const/let ? (maybe related to #11)
- Bump typescript

The tests are all running. Is there anything else to keep in mind before making the change?
Also I propose to add dependabot so that these updates will be semi-automatic in the future. ([see here for an example configuration](https://github.com/ultimate-ttt/ultimate-ttt/blob/main/.github/dependabot.yml))