### PR TITLE
chore: bump buffer to ^6.0.3 and bloomfilter to ^1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@napi-rs/uuid": "^0.2.0",
     "benchmark": "^2.1.4",
-    "bloomfilter": "^0.0.18",
+    "bloomfilter": "^1.1.0",
     "eslint": "^9.39.4",
     "hashids": "^2.2.8",
     "nanoid": "^3.0.0",
@@ -50,7 +50,7 @@
     "uuid": "^14.0.0"
   },
   "dependencies": {
-    "buffer": "^5.2.1"
+    "buffer": "^6.0.3"
   },
   "browser": {
     "./uuid-node.js": "./uuid-browser.js"


### PR DESCRIPTION
## Summary
- Bumps `buffer` (runtime dep) from `^5.2.1` to `^6.0.3`.
- Bumps `bloomfilter` (devDep, used by the uniqueness test only) from `^0.0.18` to `^1.1.0`.

Both are major-version jumps, which is why the existing caret ranges would not pick them up.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typescript` passes
- [x] `tape test/test.js test/buffer.js` passes (buffer fallback path exercised via proxyquire)
- [x] `tape test/uniqueness.js` passes — 6/6 tests, 0 bloom-filter conflicts across ~2M generated ids (confirms the `bloomfilter@1.x` API is still compatible)